### PR TITLE
add DLN spec on mev-job-board

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Need a bot? Or looking for MEV? You've come to the right place partner 🤠
 | Maker wstETH liquidations        | Liquidations   | Reocurring                 | Liquidate bad wstETH debt positions on Maker to earn liquidation bonus | [Link](/specs/maker-wsteth-liquidations.md)
 | Vesper VUSD Arbitrage        | Arbitrage   | Reocurring                 | Arbitrage between the VUSD and USDC/DAI | [Link](/specs/vusd-arbitrage.md)
 | Liquity             | Liquidations |       Reocurring       | Liquidate undercollateralized Troves to earn liquidation bonus  | [Link](/specs/liquity-liquidations.md)  |
+| DLN             | Arbitrage |       Reocurring       | Earn an arbitrage for fulfilling cross-chain limit orders via DLN, completely non-custodially | [Link](/specs/DLN-arbitrage.md)  |
 
 ### Want to list your protocol's opportunity?
 

--- a/specs/DLN-arbitrage.md
+++ b/specs/DLN-arbitrage.md
@@ -1,0 +1,29 @@
+## Earn an arbitrage for fulfilling cross-chain limit orders via DLN, completely non-custodially
+
+### Description
+
+In DLN, when a maker creates a cross-chain limit order, takers on the destination chain are able to track and analyze all the incoming trades with the taker script and can automatically fulfill it if it’s profitable.
+
+The taker that fulfills the order first then broadcasts a cross-chain message to the source chain through deBridge infrastructure to unlock the assets on the source chain, therefore earning an arbitrage spread. Routing is built in a way so takers don’t need to bear volatility risks as they provide and unlock the same asset e.g. USDC or ETH.
+
+### Difficulty
+
+Low to medium - depending if complex trading / rebalancing strategies are desired by the designated taker
+
+### Is this a one-off opportunity or is it reoccurring?
+
+This is a reoccurring MEV. As cross-chain limit orders continue to pass through DLN, there will be more opportunities to fulfill limit orders.
+
+### Steps to capture MEV
+
+1. Set up a wallet address on a compatible chain.
+2. Add a balance sheet of tokens onto the wallet address that aligns with the taker’s trading strategy (usually ETH and USDC).
+3. Run the taker script to automatically identify cross-chain limit orders: https://github.com/debridge-finance/dln-taker/
+4. Start fulfilling cross-chain limit orders and rebalance liquidity if needed.
+
+### References
+
+- App: https://dln.trade/ or https://app.debridge.finance/
+- More information on DLN orders: https://app.debridge.finance/orders
+- More information on the taker script (has a Readme section): https://github.com/debridge-finance/dln-taker/
+- Example of cross-chain order where a taker earned 0.14 ETH: https://app.debridge.finance/order?orderId=0x553908c09dfdd25c18b9e0fbd4ad5fdb05d6b031ae631f6f847043d5a07662ab


### PR DESCRIPTION
This PR adds a [DLN](https://dln.trade/) spec to the mev-job-board